### PR TITLE
Remove maven settings with only public repos

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,9 @@
 def UPSTREAM_PROJECTS_LIST = [ "Mule-runtime/metadata-model-api/support/1.2.0" ]
 
 Map pipelineParams = [ "upstreamProjects" : UPSTREAM_PROJECTS_LIST.join(','),
+                       // Comment public setting to get org.mule.runtime:api-annotations:jar:1.1.0-20200709 from private
+                       // repo until it is released in a public repo
+                       // "mavenSettingsXmlId" : "mule-runtime-maven-settings-MuleSettings",
                        "mavenSettingsXmlId" : "mule-runtime-maven-settings-MuleSettings",
                        "projectType" : "Runtime",
                        "enableMavenTestStage": false ]


### PR DESCRIPTION
This is to avoid failing trying to resolve org.mule.runtime:api-annotations:jar:1.1.0-20200709
which only is available in private repos ci-releases and releases-ee