### PR TITLE
W-13517980: Revapi validation must point to latest stable version, not a

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
 
         <maven.enforcer.plugin.version>1.4.1</maven.enforcer.plugin.version>
         <revapi-maven-plugin.version>0.9.5</revapi-maven-plugin.version>
-        <oldMuleArtifactVersion>1.5.0-SNAPSHOT</oldMuleArtifactVersion>
+        <oldMuleArtifactVersion>1.4.0</oldMuleArtifactVersion>
         <muleRevapiExtensionVersion>1.6.0-SNAPSHOT</muleRevapiExtensionVersion>
         <build.helper.maven.plugin.version>3.0.0</build.helper.maven.plugin.version>
 


### PR DESCRIPTION
snapshot